### PR TITLE
Don't include global braces in the code output

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ var extractCode = function (code, offset) {
     offset = code.indexOf('{', offset);
   }
 
-  var start = offset;
-  var cursor = offset;
-  var depth = 0;
+  var start = offset + 1; // Ignore the opening brace
+  var cursor = start;
+  var depth = 1; // The opening brace is consumed
   var length = code.length;
 
   var inString = false;
@@ -29,10 +29,6 @@ var extractCode = function (code, offset) {
 
   // In block comment (line comments are instantly consumed)
   var inComment = false;
-
-  // Consume the first brace
-  cursor++;
-  depth++;
 
   while (cursor < length && depth > 0) {
     var cb = code[cursor - 1]; // Char before
@@ -91,6 +87,9 @@ var extractCode = function (code, offset) {
   if (depth > 0) {
     return '';
   }
+
+  // Ignore the closing brace
+  cursor--;
 
   return code.substring(start, cursor);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -37,8 +37,8 @@ describe('ScssCommentParser', function () {
 
     it('should contain the whole code in `context.code` function and mixin', function () {
       var result = parser.parse(scss);
-      assert.equal(result['function'][0].context.code, '{\n  $some : "code";\n}');
-      assert.equal(result.mixin[0].context.code, '{\n  $some : "code}}";\n  /* } */\n  // }\n}');
+      assert.equal(result['function'][0].context.code, '\n  $some : "code";\n');
+      assert.equal(result.mixin[0].context.code, '\n  $some : "code}}";\n  /* } */\n  // }\n');
     });
 
     it('should allow dash in function/mixin name', function () {
@@ -110,12 +110,12 @@ describe('ScssCommentParser', function () {
 
   describe('#extractCode', function () {
     it('should extract a code block', function () {
-      assert.equal(parser.extractCode('{{ test }}'), '{{ test }}');
-      assert.equal(parser.extractCode('{{ test }} ignore'), '{{ test }}');
-      assert.equal(parser.extractCode('{{ te"te}}st"st }} ignore'), '{{ te"te}}st"st }}');
-      assert.equal(parser.extractCode('{{ te\'te}}st\'st }} ignore'), '{{ te\'te}}st\'st }}');
-      assert.equal(parser.extractCode('{{ // }\n }} ignore'), '{{ // }\n }}');
-      assert.equal(parser.extractCode('{{ /* }} */ }}'), '{{ /* }} */ }}');
+      assert.equal(parser.extractCode('{{ test }}'), '{ test }');
+      assert.equal(parser.extractCode('{{ test }} ignore'), '{ test }');
+      assert.equal(parser.extractCode('{{ te"te}}st"st }} ignore'), '{ te"te}}st"st }');
+      assert.equal(parser.extractCode('{{ te\'te}}st\'st }} ignore'), '{ te\'te}}st\'st }');
+      assert.equal(parser.extractCode('{{ // }\n }} ignore'), '{ // }\n }');
+      assert.equal(parser.extractCode('{{ /* }} */ }}'), '{ /* }} */ }');
     });
   });
 });


### PR DESCRIPTION
So the following code:

```
{$foo: 42;}
```

... will return:

```
$foo: 42;
```

That's what SassDoc expects in its tests.
