### PR TITLE
Can parse CSS rule code contexts, too.

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,13 @@ var scssContextParser = (function () {
           end : lineNumberFor(endIndex) + 1
         };
       }
+    } else {
+      var codeStart = ctxCode.indexOf('{');
+      if (codeStart > 0) {
+        context.type = 'css';
+        context.name = ctxCode.slice(0, codeStart).trim();
+        context.value = extractCode(ctxCode, codeStart).trim();
+      }
     }
 
     return context;

--- a/test/fixtures/rule.test.scss
+++ b/test/fixtures/rule.test.scss
@@ -1,0 +1,7 @@
+.foo {
+  font-weight: bold;
+  color: red;
+  .bar {
+    color: blue;
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -137,6 +137,17 @@ describe('ScssCommentParser', function () {
       });
     });
 
+    describe('css rule', function(){
+      it('should detect it', function(){
+        var context = parser.contextParser(getContent('rule.test.scss'));
+        assert.deepEqual(context, {
+          type: 'css',
+          name: '.foo',
+          value: 'font-weight: bold;\n  color: red;\n  .bar {\n    color: blue;\n  }'
+        });
+      });
+    });
+
     describe('unknown', function(){
       it('should assing unknown', function(){
         var context = parser.contextParser(getContent('unknown.test.scss'));


### PR DESCRIPTION
Hi! We'd like to use SassDoc as part of a "living styleguide" system for our projects, and for this to work it needs to have the capability to annotate CSS rule blocks as well as functions/variables/mixins/placeholders. This pull request adds that capability to the comments context parser.

I see that the broad concept has been rejected before, on "do just one thing" grounds (e.g. see https://github.com/SassDoc/sassdoc/issues/268), but I'd like to request re-consideration. Accepting this small PR does not mean changing the primary supported purpose of SassDoc in any way, it just adds a bit more flexibility for those of us who want to experiment with extending SassDoc in "off the beaten path" ways, without harming or impacting the existing uses at all.

Thoughts? Thanks for considering.