### PR TITLE
Fix interpolated selector parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ var scssContextParser = (function () {
         context.scope = match[5] || 'private';
       }
     } else {
-      startIndex = ctxCode.indexOf('{');
+      startIndex = findCodeStart(ctxCode, 0);
       endIndex = ctxCode.length - 1;
       if (startIndex > 0) {
         context.type = 'css';


### PR DESCRIPTION
This little change is supposed to fix https://github.com/SassDoc/sassdoc/issues/469.

It makes this...

```sass
.push-#{$breakpoint}-left {
  padding-left: $width;
}
```

... parse from this...

`name`: `.push-#`
`code`: `$breakpoint`

... to that...

`name`: `.push-#{$breakpoint}-left`
`code`: `padding-left: $width;`

And it does that by using a function you already had in your code base, the `findCodeStart(ctxCode, lastMatch)` function.