### PR TITLE
Fix annotation parsing in nested comment blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,20 +168,21 @@ var scssContextParser = (function () {
 var filterAndGroup = function (lines) {
   var nLines = [];
   var group = false;
-  lines.forEach(function (line){
-    var isAnnotation = line.indexOf('@') === 0;
-    if (line.trim().indexOf('---') !== 0) { // Ignore lines that start with "---"
-      if (group){
-        if ( isAnnotation ) {
-          nLines.push(line);
+  lines.forEach(function (line) {
+    var trimmedLine = line.trim();
+    var isAnnotation = trimmedLine.indexOf('@') === 0;
+    if (trimmedLine.trim().indexOf('---') !== 0) { // Ignore lines that start with "---"
+      if (group) {
+        if (isAnnotation) {
+          nLines.push(trimmedLine);
         } else {
-          nLines[nLines.length - 1] += '\n' + line ;
+          nLines[nLines.length - 1] += '\n' + line;
         }
       } else if (isAnnotation) {
         group = true;
-        nLines.push(line);
+        nLines.push(trimmedLine);
       } else {
-        nLines.push(line);
+        nLines.push(trimmedLine);
       }
     }
   });


### PR DESCRIPTION
I need to be able to document classes that are nested. Like in this example:

```sass
@each $breakpoint in map-keys($grid-breakpoints) {
  @include media-breakpoint-up($breakpoint) {

    /// text
    ///
    /// @example
    ///   <div class="fade-in-xs-up">
    ///     <span>Test</span>
    ///   </div>
    .fade-in-#{$breakpoint}-up {
      // ...
    }
  }
}
```

This works, except for all the annotation handling. Annotations don't get recognized and all land in the description. The reason for that is how indented comments get returned from `CDocParser.CommentExtractor`. The snippet above would result in this output:

```json
{
  "lines": [
    "text",
    "   ",
    "    @example",
    "      <div class=\"fade-in-xs-up\">",
    "        <span>Test</span>",
    "      </div>"
  ],
  "type": "line",
  "commentRange": {
    "start": 43,
    "end": 48
  },
  "context": {}
}
```

The `filterAndGroup` function then filters and groups the lines and uses the following to detect annotations:

```js
lines.forEach(function (line){
  var isAnnotation = line.indexOf('@') === 0;
```

This of course doesn't work, because some of the lines are indented.

This fix trims the comment lines to detect annotations, uses the trimmed lines when pushing into a new group and then keeps using the untrimmed line so intentional indentation doesn't get lost (ex. in @example source code). 