### PR TITLE
Slashes in names

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ var addCodeToContext = function (context, ctxCode, match) {
  * SCSS Context Parser
  */
 var scssContextParser = (function () {
-  var ctxRegEx = /^(@|%|\$)([\w-_]+)*(?:\s+([\w-_]+)|[\s\S]*?:([\s\S]*?)(?:\s!(\w+))?;[ \t]*?(?=\/\/|\n|$))?/
+  var ctxRegEx = /^(@|%|\$)([\w-_\\]+)*(?:\s+([\w-_\\]+)|[\s\S]*?:([\s\S]*?)(?:\s!(\w+))?;[ \t]*?(?=\/\/|\n|$))?/
   var parser = function (ctxCode, lineNumberFor) {
     var match = ctxRegEx.exec(ctxCode.trim())
     var startIndex, endIndex

--- a/test/fixtures/functionNameWithBackslash.test.scss
+++ b/test/fixtures/functionNameWithBackslash.test.scss
@@ -1,0 +1,3 @@
+@function function\with\backslash(){
+  $some : "code";
+}

--- a/test/fixtures/mixinNameWithBackslash.test.scss
+++ b/test/fixtures/mixinNameWithBackslash.test.scss
@@ -1,0 +1,3 @@
+@mixin mixin\with\backslash(){
+  $some : "code";
+}

--- a/test/fixtures/placeholderNameWithBackslash.test.scss
+++ b/test/fixtures/placeholderNameWithBackslash.test.scss
@@ -1,0 +1,3 @@
+%placeholder\with\backslash {
+  $some : "code";
+}

--- a/test/fixtures/variableNameWithBackslash.test.scss
+++ b/test/fixtures/variableNameWithBackslash.test.scss
@@ -1,0 +1,1 @@
+$variable\with\backslash : 'value';

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,15 @@ describe('scss-comment-parser', function () {
           code: '\n  $some : "code";\n'
         })
       })
+
+      it('should work for a name that contains a backslash', function () {
+        var context = parser.contextParser(getContent('placeholderNameWithBackslash.test.scss'))
+        assert.deepEqual(context, {
+          type: 'placeholder',
+          name: 'placeholder\\with\\backslash',
+          code: '\n  $some : "code";\n'
+        })
+      })
     })
 
     describe('mixin', function () {
@@ -58,6 +67,15 @@ describe('scss-comment-parser', function () {
         var context = parser.contextParser(getContent('mixinLinebreaks.test.scss'))
         assert.deepEqual(context, expected)
       })
+
+      it('should work for a name that contains a backslash', function () {
+        var context = parser.contextParser(getContent('mixinNameWithBackslash.test.scss'))
+        assert.deepEqual(context, {
+          type: 'mixin',
+          name: 'mixin\\with\\backslash',
+          code: '\n  $some : "code";\n'
+        })
+      })
     })
 
     describe('function', function () {
@@ -75,6 +93,15 @@ describe('scss-comment-parser', function () {
       it('should detect it with linebreaks', function () {
         var context = parser.contextParser(getContent('functionLinebreaks.test.scss'))
         assert.deepEqual(context, expected)
+      })
+
+      it('should work for a name that contains a backslash', function () {
+        var context = parser.contextParser(getContent('functionNameWithBackslash.test.scss'))
+        assert.deepEqual(context, {
+          type: 'function',
+          name: 'function\\with\\backslash',
+          code: '\n  $some : "code";\n'
+        })
       })
     })
 
@@ -142,6 +169,16 @@ describe('scss-comment-parser', function () {
           type: 'variable',
           name: 'name',
           value: '\'separated;value\'',
+          scope: 'private'
+        })
+      })
+
+      it('should work for a name that contains a backslash', function () {
+        var context = parser.contextParser(getContent('variableNameWithBackslash.test.scss'))
+        assert.deepEqual(context, {
+          type: 'variable',
+          name: 'variable\\with\\backslash',
+          value: '\'value\'',
           scope: 'private'
         })
       })


### PR DESCRIPTION
Goal: Add the ability for the parser to be able to read names that contain backslashes.

We are currently using backslashes for denoting namespaces, but this doesn't work well with SassDoc. Updating the regex should allow for this without any adverse side effects. I've added tests to check for this as well.